### PR TITLE
add colcon_cd function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ dist: trusty
 sudo: true
 install:
   - pip install -U setuptools
+  # install_requires
+  - pip install -U git+https://github.com/colcon/colcon-core
+  - pip install -U git+https://github.com/colcon/colcon-package-information
   # tests_require
   - pip install -U flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-quotes pep8-naming pylint pytest pytest-cov scspell3k
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,9 @@ environment:
     - PYTHON: "C:\\Python36-x64"
 install:
   - "%PYTHON%\\python.exe -m pip install -U setuptools"
+  # install_requires
+  - "%PYTHON%\\python.exe -m pip install -U git+https://github.com/colcon/colcon-core"
+  - "%PYTHON%\\python.exe -m pip install -U git+https://github.com/colcon/colcon-package-information"
   # tests_require
   - "%PYTHON%\\python.exe -m pip install -U flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-quotes pep8-naming pylint pytest pytest-cov scspell3k"
 build: off

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,5 @@
+{
+    "hooks": [
+        "share/colcon_cd/function/colcon_cd.sh"
+    ]
+}

--- a/function/colcon_cd.sh
+++ b/function/colcon_cd.sh
@@ -36,6 +36,13 @@ colcon_cd() {
 
       _colcon_cd_pkg_path="$(COLCON_LOG_PATH=/dev/null $_colcon_cd_cmd 2> /dev/null)"
       if [ $? -eq 0 ] && [ "$_colcon_cd_pkg_path" != "" ]; then
+        # count number of returned paths
+        if (( $(grep -c . <<< "$_colcon_cd_pkg_path") > 1 )); then
+          echo "Found in multiple directories:"
+          echo "$_colcon_cd_pkg_path"
+          _colcon_cd_pkg_path="$(grep -m 1 . <<< "$_colcon_cd_pkg_path")"
+          echo "cd to the first one"
+        fi
         cd "$_colcon_cd_pkg_path"
         unset _colcon_cd_pkg_path
         unset _colcon_cd_pwd
@@ -56,6 +63,13 @@ colcon_cd() {
         echo "Saved the directory '$_colcon_cd_root' for future invocations" \
           "of 'colcon_cd <pkgname>' as well as to return to using " \
           "'colcon_cd'. Call 'colcon_cd --reset' to unset the saved path."
+      fi
+      # count number of returned paths
+      if (( $(grep -c . <<< "$_colcon_cd_pkg_path") > 1 )); then
+        echo "Found in multiple directories:"
+        echo "$_colcon_cd_pkg_path"
+        _colcon_cd_pkg_path="$(grep -m 1 . <<< "$_colcon_cd_pkg_path")"
+        echo "cd to the first one"
       fi
       cd "$_colcon_cd_pkg_path"
       unset _colcon_cd_pkg_path

--- a/function/colcon_cd.sh
+++ b/function/colcon_cd.sh
@@ -1,0 +1,79 @@
+# copied from colcon_cd/function/colcon_cd.sh
+
+colcon_cd() {
+  if [ $# = 0 ]; then
+    # change the working directory to the previously saved path
+    if [ "$_colcon_cd_root" = "" ]; then
+      echo "No previous path saved. Either call 'colcon_cd <pkgname>' from a" \
+        "directory where <pkgname> can be found or 'colcon_cd --set' to" \
+        "directly save the current working directory." 1>&2
+      return 1
+    fi
+    if [ "$_colcon_cd_root" != "$(pwd)" ]; then
+      cd "$_colcon_cd_root"
+    fi
+
+  elif [ $# = 1 ]; then
+    if [ "$1" = "--set" ]; then
+      # store the current working directory for future invocations
+      _colcon_cd_root="$(pwd)"
+      echo "Saved the current working directory for future invocations of" \
+        "'colcon_cd <pkgname>' as well as to return to using 'colcon_cd'." \
+        "Call 'colcon_cd --reset' to unset the saved path."
+      return 0
+    elif [ "$1" = "--reset" ]; then
+      # unset the save path
+      unset _colcon_cd_root
+      return 0
+    fi
+
+    _colcon_cd_cmd="colcon list --packages-select $1 --paths-only"
+
+    if [ "$_colcon_cd_root" != "" ]; then
+      # try to find the given package from the saved path
+      _colcon_cd_pwd="$(pwd)"
+      cd "$_colcon_cd_root"
+
+      _colcon_cd_pkg_path="$(COLCON_LOG_PATH=/dev/null $_colcon_cd_cmd 2> /dev/null)"
+      if [ $? -eq 0 ] && [ "$_colcon_cd_pkg_path" != "" ]; then
+        cd "$_colcon_cd_pkg_path"
+        unset _colcon_cd_pkg_path
+        unset _colcon_cd_pwd
+        return 0
+      fi
+      unset _colcon_cd_pkg_path
+
+      cd "$_colcon_cd_pwd"
+      unset _colcon_cd_pwd
+    fi
+
+    # try to find the given package from the current working directory
+    _colcon_cd_pkg_path="$(COLCON_LOG_PATH=/dev/null $_colcon_cd_cmd 2> /dev/null)"
+    if [ $? -eq 0 ] && [ "$_colcon_cd_pkg_path" != "" ]; then
+      if [ "$_colcon_cd_root" = "" ]; then
+        # store the current working directory for future invocations
+        _colcon_cd_root="$(pwd)"
+        echo "Saved the directory '$_colcon_cd_root' for future invocations" \
+          "of 'colcon_cd <pkgname>' as well as to return to using " \
+          "'colcon_cd'. Call 'colcon_cd --reset' to unset the saved path."
+      fi
+      cd "$_colcon_cd_pkg_path"
+      unset _colcon_cd_pkg_path
+      return 0
+    fi
+    unset _colcon_cd_pkg_path
+
+    if [ "$_colcon_cd_root" != "" ]; then
+      echo "Could neither find package '$1' from '$_colcon_cd_root' nor from" \
+        "the current working directory" 1>&2
+    else
+      echo "Could not find package '$1' from the current working" \
+        "directory" 1>&2
+    fi
+    return 1
+
+  else
+    echo "'colcon_cd' only supports zero or one arguments" 1>&2
+    return 1
+  fi
+}

--- a/function/colcon_cd.sh
+++ b/function/colcon_cd.sh
@@ -27,14 +27,12 @@ colcon_cd() {
       return 0
     fi
 
-    _colcon_cd_cmd="colcon list --packages-select $1 --paths-only"
-
     if [ "$_colcon_cd_root" != "" ]; then
       # try to find the given package from the saved path
       _colcon_cd_pwd="$(pwd)"
       cd "$_colcon_cd_root"
 
-      _colcon_cd_pkg_path="$(COLCON_LOG_PATH=/dev/null $_colcon_cd_cmd 2> /dev/null)"
+      _colcon_cd_pkg_path="$(COLCON_LOG_PATH=/dev/null colcon list --packages-select $1 --paths-only 2> /dev/null)"
       if [ $? -eq 0 ] && [ "$_colcon_cd_pkg_path" != "" ]; then
         # count number of returned paths
         if (( $(grep -c . <<< "$_colcon_cd_pkg_path") > 1 )); then
@@ -55,7 +53,7 @@ colcon_cd() {
     fi
 
     # try to find the given package from the current working directory
-    _colcon_cd_pkg_path="$(COLCON_LOG_PATH=/dev/null $_colcon_cd_cmd 2> /dev/null)"
+    _colcon_cd_pkg_path="$(COLCON_LOG_PATH=/dev/null colcon list --packages-select $1 --paths-only 2> /dev/null)"
     if [ $? -eq 0 ] && [ "$_colcon_cd_pkg_path" != "" ]; then
       if [ "$_colcon_cd_root" = "" ]; then
         # store the current working directory for future invocations

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,9 @@ long_description = file: README.rst
 keywords = colcon
 
 [options]
+install_requires =
+  colcon-core
+  colcon-package-information
 packages = find:
 tests_require =
   flake8
@@ -41,6 +44,11 @@ tests_require =
   pytest-cov
   scspell3k>=2.2
 zip_safe = true
+
+[options.data_files]
+# distutils replaces dashes in keys with underscores
+share/colcon_cd/function =
+    function/colcon_cd.sh
 
 [tool:pytest]
 filterwarnings =


### PR DESCRIPTION
* `colcon_cd <pkgname>` will change the current working directory to the directory the specified package was found (usually in the source space)
  * if multiple locations are found they are all printed and the current working directory is switched to the first one
* `colcon_cd` changes the current working directory back to where the first command was called initially (usually the root of a workspace)

Requires colcon/colcon-core#240 and colcon/colcon-output#23.