### PR TITLE
add minimum version for flake8 to provide extend_ignore

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
   colcon-package-information
 packages = find:
 tests_require =
-  flake8
+  flake8>=3.6.0
   flake8-blind-except
   flake8-builtins
   flake8-class-newline


### PR DESCRIPTION
Same as colcon/colcon-core#260.