### PR TITLE
Add colcon_cd bash completer

### DIFF
--- a/colcon_cd/completer.py
+++ b/colcon_cd/completer.py
@@ -5,7 +5,7 @@ from colcon_argcomplete.argument_parser.argcomplete.completer.package_name \
     import package_name_completer
 import argcomplete
 import argparse
-from argcomplete.completers import SuppressCompleter
+# from argcomplete.completers import SuppressCompleter
 
 
 def main():
@@ -20,7 +20,7 @@ def main():
     # base_path argument is needed for package_name_completer
     parser.add_argument(
         "--base-paths",
-        default='.').completer = SuppressCompleter()
+        default='.')  # .completer = SuppressCompleter()
 
     # Add --set and --unset argument for the completer
     parser.add_argument("--set")

--- a/colcon_cd/completer.py
+++ b/colcon_cd/completer.py
@@ -34,5 +34,6 @@ def main():
     argcomplete.autocomplete(parser)
     parser.parse_args()
 
+
 if __name__ == '__main__':
     main()

--- a/colcon_cd/completer.py
+++ b/colcon_cd/completer.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Chen Bainian
+# Licensed under the Apache License, Version 2.0
+
+from colcon_argcomplete.argument_parser.argcomplete.completer.package_name \
+    import package_name_completer
+import argcomplete
+import argparse
+from argcomplete.completers import SuppressCompleter
+
+
+def main():
+    """
+    Fake command with parser for colcon_cd completer.
+
+    Using --external-argcomplete-script to construct
+    a bash completer for the colcon_cd command.
+    """
+    parser = argparse.ArgumentParser()
+
+    # base_path argument is needed for package_name_completer
+    parser.add_argument(
+        "--base-paths",
+        default='.').completer = SuppressCompleter()
+
+    # Add --set and --unset argument for the completer
+    parser.add_argument("--set")
+
+    parser.add_argument("--unset")
+
+    # Add package name completer
+    parser.add_argument(
+        'package_name').completer = package_name_completer
+
+    argcomplete.autocomplete(parser)
+    parser.parse_args()

--- a/colcon_cd/completer.py
+++ b/colcon_cd/completer.py
@@ -34,3 +34,6 @@ def main():
 
     argcomplete.autocomplete(parser)
     parser.parse_args()
+
+if __name__ == '__main__':
+    main()

--- a/colcon_cd/completer.py
+++ b/colcon_cd/completer.py
@@ -1,10 +1,11 @@
 # Copyright 2021 Chen Bainian
 # Licensed under the Apache License, Version 2.0
 
+import argparse
+
+import argcomplete
 from colcon_argcomplete.argument_parser.argcomplete.completer.package_name \
     import package_name_completer
-import argcomplete
-import argparse
 # from argcomplete.completers import SuppressCompleter
 
 
@@ -19,13 +20,13 @@ def main():
 
     # base_path argument is needed for package_name_completer
     parser.add_argument(
-        "--base-paths",
+        '--base-paths',
         default='.')  # .completer = SuppressCompleter()
 
     # Add --set and --unset argument for the completer
-    parser.add_argument("--set")
+    parser.add_argument('--set')
 
-    parser.add_argument("--unset")
+    parser.add_argument('--unset')
 
     # Add package name completer
     parser.add_argument(

--- a/colcon_cd/completer.py
+++ b/colcon_cd/completer.py
@@ -6,7 +6,6 @@ import argparse
 import argcomplete
 from colcon_argcomplete.argument_parser.argcomplete.completer.package_name \
     import package_name_completer
-# from argcomplete.completers import SuppressCompleter
 
 
 def main():
@@ -21,7 +20,7 @@ def main():
     # base_path argument is needed for package_name_completer
     parser.add_argument(
         '--base-paths',
-        default='.')  # .completer = SuppressCompleter()
+        default='.')
 
     # Add --set and --unset argument for the completer
     parser.add_argument('--set')

--- a/colcon_cd/completer.py
+++ b/colcon_cd/completer.py
@@ -12,7 +12,7 @@ def main():
     """
     Fake command with parser for colcon_cd completer.
 
-    Using --external-argcomplete-script to construct
+    Using package_name_completer to construct
     a bash completer for the colcon_cd command.
     """
     parser = argparse.ArgumentParser()
@@ -22,10 +22,10 @@ def main():
         '--base-paths',
         default='.')
 
-    # Add --set and --unset argument for the completer
+    # Add --set and --reset argument for the completer
     parser.add_argument('--set')
 
-    parser.add_argument('--unset')
+    parser.add_argument('--reset')
 
     # Add package name completer
     parser.add_argument(

--- a/function/colcon_cd-argcomplete.bash
+++ b/function/colcon_cd-argcomplete.bash
@@ -1,50 +1,5 @@
-# Copied from argcomplete shell_integration.py
-# https://github.com/kislyuk/argcomplete/blob/v1.12.3/argcomplete/shell_integration.py#L9-L53
-# argcomplete version earlier than 1.12 does not support --external-argcomplete-script
-
-# Run something, muting output or redirecting it to the debug stream
-# depending on the value of _ARC_DEBUG.
-# If ARGCOMPLETE_USE_TEMPFILES is set, use tempfiles for IPC.
-__python_argcomplete_run() {
-    if [[ -z "${ARGCOMPLETE_USE_TEMPFILES-}" ]]; then
-        __python_argcomplete_run_inner "$@"
-        return
-    fi
-    local tmpfile="$(mktemp)"
-    _ARGCOMPLETE_STDOUT_FILENAME="$tmpfile" __python_argcomplete_run_inner "$@"
-    local code=$?
-    cat "$tmpfile"
-    rm "$tmpfile"
-    return $code
-}
-__python_argcomplete_run_inner() {
-    if [[ -z "${_ARC_DEBUG-}" ]]; then
-        "$@" 8>&1 9>&2 1>/dev/null 2>&1
-    else
-        "$@" 8>&1 9>&2 1>&9 2>&1
-    fi
-}
-_python_argcomplete__colcon_cd_completions() {
-    local IFS=$'\013'
-    local SUPPRESS_SPACE=0
-    if compopt +o nospace 2> /dev/null; then
-        SUPPRESS_SPACE=1
-    fi
-    COMPREPLY=( $(IFS="$IFS" \
-                  COMP_LINE="$COMP_LINE" \
-                  COMP_POINT="$COMP_POINT" \
-                  COMP_TYPE="$COMP_TYPE" \
-                  _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
-                  _ARGCOMPLETE=1 \
-                  _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
-                  __python_argcomplete_run python3 -m colcon_cd.completer) )
-    if [[ $? != 0 ]]; then
-        unset COMPREPLY
-    elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then
-        compopt -o nospace
-    fi
-}
-
-if type register-python-argcomplete3 > /dev/null 2>&1 || type register-python-argcomplete > /dev/null 2>&1; then
-  complete -o default -o nospace -F _python_argcomplete__colcon_cd_completions colcon_cd
+if type register-python-argcomplete3 > /dev/null 2>&1; then
+  eval "$(register-python-argcomplete3 colcon_cd)"
+elif type register-python-argcomplete > /dev/null 2>&1; then
+  eval "$(register-python-argcomplete colcon_cd)"
 fi

--- a/function/colcon_cd-argcomplete.bash
+++ b/function/colcon_cd-argcomplete.bash
@@ -1,0 +1,50 @@
+# Copied from argcomplete shell_integration.py
+# https://github.com/kislyuk/argcomplete/blob/v1.12.3/argcomplete/shell_integration.py#L9-L53
+# argcomplete version earlier than 1.12 does not support --external-argcomplete-script
+
+# Run something, muting output or redirecting it to the debug stream
+# depending on the value of _ARC_DEBUG.
+# If ARGCOMPLETE_USE_TEMPFILES is set, use tempfiles for IPC.
+__python_argcomplete_run() {
+    if [[ -z "${ARGCOMPLETE_USE_TEMPFILES-}" ]]; then
+        __python_argcomplete_run_inner "$@"
+        return
+    fi
+    local tmpfile="$(mktemp)"
+    _ARGCOMPLETE_STDOUT_FILENAME="$tmpfile" __python_argcomplete_run_inner "$@"
+    local code=$?
+    cat "$tmpfile"
+    rm "$tmpfile"
+    return $code
+}
+__python_argcomplete_run_inner() {
+    if [[ -z "${_ARC_DEBUG-}" ]]; then
+        "$@" 8>&1 9>&2 1>/dev/null 2>&1
+    else
+        "$@" 8>&1 9>&2 1>&9 2>&1
+    fi
+}
+_python_argcomplete__colcon_cd_completions() {
+    local IFS=$'\013'
+    local SUPPRESS_SPACE=0
+    if compopt +o nospace 2> /dev/null; then
+        SUPPRESS_SPACE=1
+    fi
+    COMPREPLY=( $(IFS="$IFS" \
+                  COMP_LINE="$COMP_LINE" \
+                  COMP_POINT="$COMP_POINT" \
+                  COMP_TYPE="$COMP_TYPE" \
+                  _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
+                  _ARGCOMPLETE=1 \
+                  _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
+                  __python_argcomplete_run "_colcon_cd_completions") )
+    if [[ $? != 0 ]]; then
+        unset COMPREPLY
+    elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then
+        compopt -o nospace
+    fi
+}
+
+if type register-python-argcomplete3 > /dev/null 2>&1 || type register-python-argcomplete > /dev/null 2>&1; then
+  complete -o default -o nospace -F _python_argcomplete__colcon_cd_completions colcon_cd
+fi

--- a/function/colcon_cd-argcomplete.bash
+++ b/function/colcon_cd-argcomplete.bash
@@ -37,7 +37,7 @@ _python_argcomplete__colcon_cd_completions() {
                   _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
                   _ARGCOMPLETE=1 \
                   _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
-                  __python_argcomplete_run "_colcon_cd_completions") )
+                  __python_argcomplete_run python3 -m colcon_cd.completer) )
     if [[ $? != 0 ]]; then
         unset COMPREPLY
     elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then

--- a/function/colcon_cd-argcomplete.zsh
+++ b/function/colcon_cd-argcomplete.zsh
@@ -1,3 +1,7 @@
 autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
-. ./colcon_cd-argcomplete.bash
+if type register-python-argcomplete3 > /dev/null 2>&1; then
+  eval "$(register-python-argcomplete3 colcon_cd)"
+elif type register-python-argcomplete > /dev/null 2>&1; then
+  eval "$(register-python-argcomplete colcon_cd)"
+fi

--- a/function/colcon_cd-argcomplete.zsh
+++ b/function/colcon_cd-argcomplete.zsh
@@ -1,0 +1,3 @@
+autoload -U +X compinit && compinit
+autoload -U +X bashcompinit && bashcompinit
+. ./colcon_cd-argcomplete.bash

--- a/function/colcon_cd.sh
+++ b/function/colcon_cd.sh
@@ -1,7 +1,9 @@
 # copied from colcon-cd/function/colcon_cd.sh
 
 colcon_cd() {
-  if [ $# = 0 ]; then
+  if [ "$_ARGCOMPLETE" == "1" ]; then
+    python3 -m colcon_cd.completer
+  elif [ $# = 0 ]; then
     # change the working directory to the previously saved path
     if [ "$_colcon_cd_root" = "" ]; then
       echo "No previous path saved. Either call 'colcon_cd <pkgname>' from a" \

--- a/function/colcon_cd.sh
+++ b/function/colcon_cd.sh
@@ -14,7 +14,7 @@ colcon_cd() {
     fi
 
   elif [ $# = 1 ]; then
-    if [ "$1" = "--help" ]; then
+    if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
       echo "usage: colcon_cd [--set] [--reset] [PACKAGE_NAME]"
       echo ""
       echo "Change the current working directory."

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,8 @@ packages = find:
 zip_safe = true
 
 [options.extras_require]
+completion = 
+  colcon-argcomplete
 test =
   flake8>=3.6.0
   flake8-blind-except

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,8 @@ test =
 # distutils replaces dashes in keys with underscores
 share/colcon_cd/function =
     function/colcon_cd.sh
+    function/colcon_cd-argcomplete.bash
+    function/colcon_cd-argcomplete.zsh
 
 [tool:pytest]
 filterwarnings =
@@ -64,6 +66,8 @@ junit_suite_name = colcon-cd
 [options.entry_points]
 colcon_core.extension_point =
     _colcon_cd = colcon_cd:NonFunctionalExtensionPoint
+console_scripts =
+    _colcon_cd_completions = colcon_cd.completer:main
 
 [flake8]
 import-order-style = google

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,8 +66,6 @@ junit_suite_name = colcon-cd
 [options.entry_points]
 colcon_core.extension_point =
     _colcon_cd = colcon_cd:NonFunctionalExtensionPoint
-console_scripts =
-    _colcon_cd_completions = colcon_cd.completer:main
 
 [flake8]
 import-order-style = google

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,5 +1,10 @@
 apache
+argcomplete
+argparse
+autocomplete
+bainian
 colcon
+completers
 iterdir
 pathlib
 pytest

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -4,7 +4,6 @@ argparse
 autocomplete
 bainian
 colcon
-completers
 iterdir
 pathlib
 pytest


### PR DESCRIPTION
Address #12 

I had some time to work on this and managed to add in the auto-completion feature for `colcon_cd`. The solution is a bit hackish, but I hope it will be helpful.

**How to use**

```bash
. <path-to-workspace>/install/colcon-cd/share/colcon_cd/function/colcon_cd.sh
. <path-to-workspace>/install/colcon-cd/share/colcon_cd/function/colcon_cd-argcomplete.bash
# . <path-to-workspace>/install/colcon-cd/share/colcon_cd/function/colcon_cd-argcomplete.zsh
```

My original intention is to make use of `argcomplete`'s [--external-argcomplete-script](https://kislyuk.github.io/argcomplete/#external-argcomplete-script) to create a fake console command (entrypoint name: `_colcon_cd_completions`) and use that console command for bash completion. This is implemented in `completer.py`.

However, due to the `argcomplete` version differences between [bootstrap setup](https://colcon.readthedocs.io/en/released/developer/bootstrap.html) pip ([`1.12.3`](https://pypi.org/project/argcomplete/1.12.3/)) and Ubuntu 20.04 native `python3-argcomplete` ([`1.8.1`](https://ubuntu.pkgs.org/20.04/ubuntu-universe-amd64/python3-argcomplete_1.8.1-1.3ubuntu1_all.deb.html)), I have to include the **entire bash script** from [argcomplete 1.12.3](https://github.com/kislyuk/argcomplete/blob/v1.12.3/argcomplete/shell_integration.py#L9-L53), and also not being able to remove the auto-completion for unused variable -- `base_path` ([ref](https://github.com/Briancbn/colcon-cd/blob/pr-bash-completion/colcon_cd/completer.py#L8)).

I have verified that it works with `bash` on Ubuntu 20.04 native and bootstrap setup, I am not familiar with `zsh` testing, it will be helpful if I could get help from the maintainers on this.

Tests pass with `colcon test` locally, CI pending https://github.com/colcon/colcon-cd/pull/13, [passed after rebase](https://github.com/Briancbn/colcon-cd/actions/runs/1453592384)

It might be easier way to do this completely in shell, but I just cannot figure it out and this was what I currently decide to go with.