### PR TITLE
Use numeric comparison for number of script arguments

### DIFF
--- a/function/colcon_cd.sh
+++ b/function/colcon_cd.sh
@@ -3,7 +3,7 @@
 colcon_cd() {
   if [ "$_ARGCOMPLETE" = "1" ]; then
     python3 -m colcon_cd.completer
-  elif [ $# = 0 ]; then
+  elif [ $# -eq 0 ]; then
     # change the working directory to the previously saved path
     if [ "$_colcon_cd_root" = "" ]; then
       echo "No previous path saved. Either call 'colcon_cd <pkgname>' from a" \
@@ -15,7 +15,7 @@ colcon_cd() {
       cd "$_colcon_cd_root"
     fi
 
-  elif [ $# = 1 ]; then
+  elif [ $# -eq 1 ]; then
     if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
       echo "usage: colcon_cd [--set] [--reset] [PACKAGE_NAME]"
       echo ""


### PR DESCRIPTION
The current script uses a string comparison. While this currently seems to work, a numeric comparison is clearly intended.

Inspired by https://github.com/colcon/colcon-cd/pull/25#discussion_r1528915597